### PR TITLE
Update to Drone 0.8.0 w/ grpc

### DIFF
--- a/Dockerfile-compile
+++ b/Dockerfile-compile
@@ -1,8 +1,14 @@
 FROM golang:1.8
-ARG drone_git_ref=v0.7.3
+ARG drone_git_ref=547514348d1836db33edeef82d68dd92620f39b4
 WORKDIR /go/src/github.com/drone/drone/
 RUN \
-  git clone https://github.com/drone/drone.git --branch $drone_git_ref --single-branch . && \
+  git clone https://github.com/drone/drone.git . && \
+  git checkout $drone_git_ref && \
   go get -u github.com/drone/drone-ui/dist && \
   go get -u golang.org/x/tools/cmd/cover && \
-  go build -ldflags '-extldflags "-static" -X github.com/drone/drone/version.VersionDev=1and1' -o release/drone github.com/drone/drone/drone
+  go get -u golang.org/x/net/context && \
+  go get -u golang.org/x/net/context/ctxhttp && \
+  go get -u github.com/golang/protobuf/proto && \
+  go get -u github.com/golang/protobuf/protoc-gen-go && \
+  go build -ldflags '-extldflags "-static" -X github.com/drone/drone/version.VersionDev=1and1' -o release/drone-server github.com/drone/drone/cmd/drone-server && \
+  GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags '-X github.com/drone/drone/version.VersionDev=1and1' -o release/drone-agent github.com/drone/drone/cmd/drone-agent

--- a/Dockerfile-package
+++ b/Dockerfile-package
@@ -26,6 +26,6 @@ RUN \
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-COPY bin/drone /opt/drone/drone
+COPY bin/drone-* /opt/drone/
 
-EXPOSE 8000 80 443
+EXPOSE 8000 9000 80 443

--- a/Makefile
+++ b/Makefile
@@ -39,15 +39,15 @@ build-binary:
 	##
 	rm -rf ${BIN_PATH} && mkdir -p ${BIN_PATH}
 	docker build ${COMPILE_BUILD_ARGS} --tag ${COMPILE_IMAGE_NAME} --file Dockerfile-compile .
-	docker cp ${CONTAINER_ID}:/go/src/github.com/drone/drone/release/drone ${BIN_PATH}
 	$(eval CONTAINER_ID=$(shell docker create ${COMPILE_IMAGE_NAME}))
+	docker cp ${CONTAINER_ID}:/go/src/github.com/drone/drone/release/. ${BIN_PATH}
 	docker rm -v ${CONTAINER_ID}
 
 build-image:
 	##
 	## Starting build of image ${IMAGE_NAME}
 	##
-	docker build ${BUILD_ARGS} --tag ${IMAGE_NAME} --file Dockerfile-container .
+	docker build ${BUILD_ARGS} --tag ${IMAGE_NAME} --file Dockerfile-package .
 
 test:
 	##

--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,8 @@ build-binary:
 	##
 	rm -rf ${BIN_PATH} && mkdir -p ${BIN_PATH}
 	docker build ${COMPILE_BUILD_ARGS} --tag ${COMPILE_IMAGE_NAME} --file Dockerfile-compile .
-	$(eval CONTAINER_ID = $(shell docker create ${COMPILE_IMAGE_NAME}))
 	docker cp ${CONTAINER_ID}:/go/src/github.com/drone/drone/release/drone ${BIN_PATH}
+	$(eval CONTAINER_ID=$(shell docker create ${COMPILE_IMAGE_NAME}))
 	docker rm -v ${CONTAINER_ID}
 
 build-image:

--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ docker build COMPILE_BUILD_ARGS = --rm --tag ${COMPILE_IMAGE_NAME} --file Docker
 # Stage 2 - Copy the drone binary to the local work space
 rm -rf bin && mkdir -p bin
 CONTAINER_ID=`docker create ${COMPILE_IMAGE_NAME}`
-docker cp ${CONTAINER_ID}:/go/src/github.com/drone/drone/release/drone bin
+docker cp ${CONTAINER_ID}:/go/src/github.com/drone/drone/release/. bin
 docker rm ${CONTAINER_ID}
 
 # Stage 3 - Build the final image
-docker build --tag ${IMAGE_NAME} .
+docker build --tag ${IMAGE_NAME} --file Dockerfile-package .
 ```
 
 ## Modifying the tests

--- a/files/etc/supervisor/conf.d/drone-agent.conf
+++ b/files/etc/supervisor/conf.d/drone-agent.conf
@@ -1,5 +1,5 @@
-[program:drone]
-command=/opt/drone/drone agent
+[program:drone-agent]
+command=/opt/drone/drone-agent
 autostart=true
 autorestart=true
 startretries=3

--- a/files/etc/supervisor/conf.d/drone-server.conf
+++ b/files/etc/supervisor/conf.d/drone-server.conf
@@ -1,5 +1,5 @@
-[program:drone]
-command=/opt/drone/drone server
+[program:drone-server]
+command=/opt/drone/drone-server
 autostart=true
 autorestart=true
 startretries=3


### PR DESCRIPTION
Agent->Server comms have been switched to GRPC and new build queue logic added improving handling of agent restarts.
Agent maintains a 10 minute timeout for builds it has started. If the deadline is reached, the server pushes that build to the top of the pending queue. Be aware that this status change is not yet reflected in the UI.